### PR TITLE
Add constructor to SuiPriceServiceConnection

### DIFF
--- a/pyth-sdk/src/SuiPriceServiceConnection.ts
+++ b/pyth-sdk/src/SuiPriceServiceConnection.ts
@@ -1,10 +1,21 @@
 import {
   PriceServiceConnection,
   HexString,
+  type PriceServiceConnectionConfig,
 } from "@pythnetwork/price-service-client";
 import { Buffer } from "buffer";
 
 export class SuiPriceServiceConnection extends PriceServiceConnection {
+  /**
+   * Constructs a new Connection.
+   *
+   * @param endpoint endpoint URL to the price service. Example: https://website/example/
+   * @param config Optional PriceServiceConnectionConfig for custom configurations.
+   */
+  constructor(endpoint: string, config?: PriceServiceConnectionConfig) {
+    super(endpoint, config);
+  }
+  
   /**
    * Gets price update data (either batch price attestation VAAs or accumulator messages, depending on the chosen endpoint), which then
    * can be submitted to the Pyth contract to update the prices. This will throw an axios error if there is a network problem or


### PR DESCRIPTION
Typescript cannot identify a constructor on `SuiPriceServiceConnection` even though it extends `PriceServiceConnection`, so a permanent fix on this is defining one and making a super call.

![Screenshot from 2024-05-20 10-27-56](https://github.com/solendprotocol/suilend-public/assets/5002506/f57c7a45-ffee-4b06-941a-21926b8f52bc)
