### PR TITLE
search engine optimisation

### DIFF
--- a/frontend/src/components/shared/Typography.tsx
+++ b/frontend/src/components/shared/Typography.tsx
@@ -14,6 +14,8 @@ import { cn } from "@/lib/utils";
 
 export const displayClassNames =
   "text-foreground font-mono text-lg font-normal";
+export const primaryTitleClassNames = 
+  "text-foreground font-mono text-lg font-normal";
 export const titleClassNames = "text-primary font-mono text-sm font-normal";
 export const bodyClassNames = "text-foreground font-mono text-sm font-normal";
 export const bodySansClassNames =
@@ -36,7 +38,23 @@ export const TDisplay = forwardRef<
 });
 TDisplay.displayName = "TDisplay";
 
-// Title
+// TODO : TTitle should accept an "as" attribute to define the component type
+// A quick poc is to create a new TPrimaryTitle component
+
+// Primary Title (h1)
+export const TPrimaryTitle = forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, children, ...props }, ref) => {
+  return (
+    <h1 ref={ref} className={cn(primaryTitleClassNames, className)} {...props}>
+      {children}
+    </h1>
+  );
+});
+TPrimaryTitle.displayName = "TPrimaryTitle";
+
+// Title (h2)
 export const TTitle = forwardRef<
   HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -51,7 +51,7 @@ export default function App({
       <SpeedInsights />
       <Analytics />
       <Head>
-        <title>Suilend</title>
+        <title>Suilend | Lending and borrowing platform on Sui</title>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -13,7 +13,7 @@ import Lava from "@/components/public/Lava";
 import Button from "@/components/shared/Button";
 import Ticker from "@/components/shared/Ticker";
 import TokenLogo from "@/components/shared/TokenLogo";
-import { TBody, TDisplay, TTitle } from "@/components/shared/Typography";
+import { TBody, TPrimaryTitle, TTitle } from "@/components/shared/Typography";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAppContext } from "@/contexts/AppContext";
 import { formatPercent } from "@/lib/format";
@@ -68,9 +68,9 @@ export default function Home() {
                   height={64}
                 />
 
-                <TDisplay className="w-full max-w-[800px] text-[32px] uppercase md:text-[48px]">
+                <TPrimaryTitle className="w-full max-w-[800px] text-[32px] uppercase md:text-[48px]">
                   Lending and borrowing platform on Sui.
-                </TDisplay>
+                </TPrimaryTitle>
 
                 <NextLink href={DASHBOARD_URL} className="w-max max-md:hidden">
                   <Button labelClassName="uppercase" size="lg">


### PR DESCRIPTION
The suilend.fi home page has no h1 tag. This PR adds a TPrimaryTitle component and also modifies the page's meta title